### PR TITLE
Add endpoint to fetch users with manager role

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Helpers\ResponseHelper;
+use App\Http\Resources\UserResource;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class UserController extends Controller
+{
+    public function getManagers()
+    {
+        $user = JWTAuth::parseToken()->authenticate();
+
+        if (!$user || !in_array($user->role, ['admin', 'hr'])) {
+            return ResponseHelper::apiError('Unauthorized', null, 403);
+        }
+
+        $managers = User::where('role', 'manager')->get();
+
+        return ResponseHelper::success(
+            'Managers fetched successfully',
+            UserResource::collection($managers)
+        );
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,8 @@ use App\Http\Controllers\DepartmentController;
 use App\Http\Controllers\EmployeeController;
 use App\Http\Controllers\PositionController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\UserController;
+
 
 Route::prefix('auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -32,4 +34,7 @@ Route::middleware(['auth:api', 'role:admin'])->prefix('admin')->group(function (
 
 Route::middleware(['auth:api', 'role:employee'])->prefix('employee')->group(function () {
     Route::get('/my', [EmployeeController::class, 'getByOwner']);
+});
+Route::middleware(['auth:api', 'role:admin,hr'])->group(function () {
+    Route::get('/users/managers', [UserController::class, 'getManagers']);
 });


### PR DESCRIPTION
Summary
- Added a new API endpoint to fetch users with the manager role
- Endpoint follows existing authentication and role-based authorization

Changes
- Added getManagers method in UserController
- Registered GET /users/managers route in api.php
- Access restricted to admin/HR roles

Note
- No existing logic was modified
- Implementation follows current project structure
